### PR TITLE
added configuration for admin login service

### DIFF
--- a/src/main/resources/config/admin-login-clouddev.yml
+++ b/src/main/resources/config/admin-login-clouddev.yml
@@ -1,0 +1,15 @@
+server:
+  port: 5000
+
+spring:
+  eureka:
+    client:
+      register-with-eureka: false
+      fetch-registry: false
+eureka:
+  client:
+    enabled: false
+    registerWithEureka: false
+    register-with-eureka: false
+    registration:
+      enabled: false

--- a/src/main/resources/config/admin-login-h2.yml
+++ b/src/main/resources/config/admin-login-h2.yml
@@ -1,0 +1,10 @@
+server:
+  port: 5000
+
+spring:
+  datasource:
+    url:  jdbc:h2:mem:db;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+    
+cloud:
+    discovery:
+      enabled: true

--- a/src/main/resources/config/admin-login-local.yml
+++ b/src/main/resources/config/admin-login-local.yml
@@ -1,0 +1,14 @@
+server:
+  port: 5000
+
+spring:
+  cloud.discovery.enabled: true
+eureka:
+  client:
+    enabled: true
+    registerWithEureka: true
+    register-with-eureka: true
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/
+    registration:
+      enabled: true

--- a/src/main/resources/config/admin-login-postgres.yml
+++ b/src/main/resources/config/admin-login-postgres.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: ${RMS_RESOURCES_DB_URL}
+    username: ${RMS_RESOURCES_DB_ROLE}
+    password: ${RMS_RESOURCES_DB_PASSWORD}
+    
+  hikari:
+    # Database connection pool size
+    maximum-pool-size: 10
+  jpa:
+    hibernate:
+      ddl-auto: update
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    properties:
+      hibernate:
+        show_sql: false
+        use_sql_comments: false
+        temp:
+          use_jdbc_metadata_default: false


### PR DESCRIPTION
Added yml files to configure profiles for the admin login service for h2 database and Eureka.

The admin-login-postgres.yml should not be used for now since a postgres database is currently not set up for the admin login service.