### PR TITLE
Added timeout configuration for hystrix for the reservation service.

### DIFF
--- a/src/main/resources/config/email-h2.yml
+++ b/src/main/resources/config/email-h2.yml
@@ -1,0 +1,10 @@
+server:
+  port: 4300
+
+spring:
+  datasource:
+    url:  jdbc:h2:mem:db;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+    
+cloud:
+    discovery:
+      enabled: true

--- a/src/main/resources/config/email-local.yml
+++ b/src/main/resources/config/email-local.yml
@@ -1,0 +1,18 @@
+server:
+  port: 4300
+
+cancelTemplate: FormattedCancellationTemplate
+confirmTemplate: FormattedConfirmationTemplate
+
+
+spring:
+  cloud.discovery.enabled: true
+eureka:
+  client:
+    enabled: true
+    registerWithEureka: true
+    register-with-eureka: true
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/
+    registration:
+      enabled: true

--- a/src/main/resources/config/email-local.yml
+++ b/src/main/resources/config/email-local.yml
@@ -2,7 +2,8 @@ server:
   port: 4300
 
 cancelTemplate: FormattedCancellationTemplate
-confirmTemplate: FormattedConfirmationTemplate
+confirmTemplate: RevatureStyleConfirm
+verifyTemplate: ConfirmRegistrationTemplate
 
 
 spring:

--- a/src/main/resources/config/email-postgres.yml
+++ b/src/main/resources/config/email-postgres.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: ${RMS_EMAIL_DB_URL}
+    username: ${RMS_EMAIL_DB_ROLE}
+    password: ${RMS_EMAIL_DB_PASSWORD}
+    
+  hikari:
+    # Database connection pool size
+    maximum-pool-size: 10
+  jpa:
+    hibernate:
+      ddl-auto: update
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    properties:
+      hibernate:
+        show_sql: false
+        use_sql_comments: false
+        temp:
+          use_jdbc_metadata_default: false

--- a/src/main/resources/config/reservations-clouddev.yml
+++ b/src/main/resources/config/reservations-clouddev.yml
@@ -16,3 +16,10 @@ eureka:
     register-with-eureka: false
     registration:
       enabled: false
+hystrix:
+  command:
+    default:
+      execution:
+        isolation:
+          thread:
+            timeoutInMilliseconds: 1500

--- a/src/main/resources/config/reservations-local.yml
+++ b/src/main/resources/config/reservations-local.yml
@@ -14,3 +14,11 @@ eureka:
       defaultZone: http://localhost:8761/eureka/
     registration:
       enabled: true
+hystrix:
+  command:
+    default:
+      execution:
+        isolation:
+          thread:
+            timeoutInMilliseconds: 1500
+            


### PR DESCRIPTION
Needed to add hystrix configuration to the yml file in order to extend timeout duration, otherwise emails wouldn't be able to send properly as they were timing out when accessing the database.
-Austin D.